### PR TITLE
feat: limit the blog post container width, ensuring images and texts scale together

### DIFF
--- a/src/theme/BlogPostPage/BlogPageLayout/BlogPageLayout.css
+++ b/src/theme/BlogPostPage/BlogPageLayout/BlogPageLayout.css
@@ -1,4 +1,3 @@
-
 .blog-page-layout {
   background-color: #F3F3F3;
   margin-top: 0;
@@ -9,10 +8,36 @@
   display: flex;
   padding: 0px 80px 40px 80px;
   gap: 80px;
+  max-width: 1800px; /* Added max-width to contain overall page width */
+  margin: 0 auto; /* Center the container */
 }
 
 .blog-page-content {
   width: 100%;
+  max-width: 1200px; /* Added max-width to control content width */
+  margin: 0 auto; /* Center the content */
+  font-size: 16px; /* Base font size for the content area */
+}
+
+/* This will make all text elements inside blog-page-content scale together */
+.blog-page-content h1,
+.blog-page-content h2,
+.blog-page-content h3,
+.blog-page-content p,
+.blog-page-content li,
+.blog-page-content span {
+  font-size: 1em; /* Set relative to the parent's font size */
+}
+
+/* Adjust specific headings as needed with em units */
+.blog-page-content h1 { font-size: 2em; } /* 32px at default scale */
+.blog-page-content h2 { font-size: 1.5em; } /* 24px at default scale */
+.blog-page-content h3 { font-size: 1.25em; } /* 20px at default scale */
+
+/* Ensure images scale with the container */
+.blog-page-content img {
+  max-width: 100%;
+  height: auto;
 }
 
 .blog-page-featured-tag-container {
@@ -24,10 +49,9 @@
   border: 1px solid #E7E7E7;
   background: #FFF;
   padding: 6px 14px;
-
   color: #000;
   font-family: Inter;
-  font-size: 14px;
+  font-size: 0.875em; /* Changed from 14px to relative unit */
   font-style: normal;
   font-weight: 600;
   line-height: normal;
@@ -35,23 +59,22 @@
 
 .blog-page-toc {
   min-width: 300px;
+  font-size: 1em; /* Base font size for TOC, will scale with page */
 }
 
-@media screen and (max-width: 996px) { 
+@media screen and (max-width: 996px) {
   .blog-page-toc {
     min-width: 0px;
   }
-
   .blog-page-container {
     gap: 0px;
   }
 }
 
-@media screen and (max-width: 767px) { 
+@media screen and (max-width: 767px) {
   .blog-page-layout {
     padding-top: 16px;
   }
-
   .blog-page-container {
     padding: 0px 16px 40px 16px;
   }


### PR DESCRIPTION
Before:

<img width="1172" alt="Screen Shot 2025-04-08 at 3 09 51 PM" src="https://github.com/user-attachments/assets/ce775071-1c13-47fa-9db3-2fb69da816e2" />

After:

<img width="1002" alt="Screen Shot 2025-04-08 at 2 45 18 PM" src="https://github.com/user-attachments/assets/c2e80ae2-bca0-4e78-ad64-ca5b83067f4f" />
