### PR TITLE
feat: new CTA colours, and fix the interest form input width

### DIFF
--- a/src/components/NewHomePage/EmailSignup/EmailSignup.tsx
+++ b/src/components/NewHomePage/EmailSignup/EmailSignup.tsx
@@ -57,24 +57,24 @@ const EmailSignUp: React.FC = () => {
           </button>
         </div>
 
-      {/* Newsletter CTA */}
-      <div className="newsletter-section bg-purple-100 flex flex-col justify-center h-full text-center shadow-md px-8 py-4 rounded-lg">
-        <img
-          src="/img/newsletter-icon.svg"
-          alt="Newsletter Icon"
-          className="mx-auto w-60 h-auto mb-6"
-        />
-        <p className="text-lg font-semibold text-panoptic-purple mb-2">
-          Subscribe for Newsletter Updates
-        </p>
-        <button
-          onClick={() => setNewsletterOpen(true)}
-          className="mt-4 px-8 py-3 bg-panoptic-purple text-white font-semibold rounded-lg hover:bg-purple-700 transition ease-in-out duration-150 active:scale-95"
-        >
-          Subscribe
-        </button>
+        {/* Newsletter CTA */}
+        <div className="newsletter-section bg-white flex flex-col justify-center h-full text-center shadow-md px-8 py-4 rounded-lg">
+          <img
+            src="/img/newsletter-icon.svg"
+            alt="Newsletter Icon"
+            className="mx-auto w-60 h-auto mb-6"
+          />
+          <p className="text-lg font-semibold text-panoptic-purple mb-2">
+            Subscribe for Newsletter Updates
+          </p>
+          <button
+            onClick={() => setNewsletterOpen(true)}
+            className="mt-4 px-8 py-3 bg-panoptic-purple text-white font-semibold rounded-lg hover:bg-purple-700 transition ease-in-out duration-150 active:scale-95"
+          >
+            Subscribe
+          </button>
+        </div>
       </div>
-    </div>
 
       {/* Interest Modal */}
       <Transition.Root show={interestOpen} as={Fragment}>
@@ -148,7 +148,7 @@ const EmailSignUp: React.FC = () => {
                             onChange={(e) => setEmail(e.target.value)}
                             required
                             placeholder="you@example.com"
-                            className="mt-1 w-full border border-gray-300 rounded-md bg-white p-3 text-base placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-panoptic-purple focus:border-panoptic-purple"
+                            className="mt-1 w-[94%] border border-gray-300 rounded-md bg-white p-3 text-base placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-panoptic-purple focus:border-panoptic-purple"
                           />
                         </div>
                         <div>
@@ -161,7 +161,7 @@ const EmailSignUp: React.FC = () => {
                             onChange={(e) => setWallet(e.target.value)}
                             required
                             placeholder="0x1234…"
-                            className="mt-1 w-full border border-gray-300 rounded-md bg-white p-3 text-base placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-panoptic-purple focus:border-panoptic-purple"
+                            className="mt-1 w-[94%] border border-gray-300 rounded-md bg-white p-3 text-base placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-panoptic-purple focus:border-panoptic-purple"
                           />
                         </div>
                         <div className="flex justify-end space-x-3 mt-6">


### PR DESCRIPTION
Before - two purple CTAs:

<img width="1602" alt="Screen Shot 2025-04-24 at 2 18 09 PM" src="https://github.com/user-attachments/assets/146da13f-b18d-4635-bb39-a5a1c9be4b4c" />

And input form for the competition interest had its width go to the very edge of its grey container:

<img width="484" alt="Screen Shot 2025-04-24 at 2 21 50 PM" src="https://github.com/user-attachments/assets/dbf1521d-e549-4904-9873-0406b91a6fa6" />

After - newsletter CTA becomes white, a direct inversion of the other CTA:

<img width="1600" alt="Screen Shot 2025-04-24 at 2 18 03 PM" src="https://github.com/user-attachments/assets/ee5b0113-a797-4a85-a49b-215153f36e9c" />

and the width of the interest form input is restricted, giving some breathing room with the edge of its container and stopping exactly where the Submit button stops

<img width="1504" alt="Screen Shot 2025-04-24 at 2 21 12 PM" src="https://github.com/user-attachments/assets/13211d95-34e8-4e87-a247-276f5b47014d" />

finally, also properly indented the newsletter CTA 😄 