### PR TITLE
Proxy homepage to webflow site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/", "destination": "https://panoptic-964459.webflow.io/" }
+  ]
+}


### PR DESCRIPTION
Attempts uses vercel rewrites feature to use vercel as a reverse proxy for the / route, while using the docusaurus site for all other routes (/blog, /docs, etc.)