### PR TITLE
feat: do not display `GiscusComponent` on mobile

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -13,7 +13,9 @@ export default function DocItem(props) {
         <DocItemMetadata />
         <DocItemLayout>
           <MDXComponent />
-          <GiscusComponent />
+  <div className="hidden md:block">
+    <GiscusComponent />
+  </div>      
         </DocItemLayout>
       </HtmlClassNameProvider>
     </DocProvider>


### PR DESCRIPTION
This PR removes the `GiscusComponent`on mobile. It was taking a lot of real estate space and commenting through their github account might not be what mobile users a looking to do.

![Recording 2025-07-24 at 17 12 53](https://github.com/user-attachments/assets/9962d7d0-2876-40b2-99ee-6a0aaa7eb6ad)
