### PR TITLE
feat: rename the Smart Contract Audits section to Core Protocol Audits + move the Vault audits after them + indicate more Vault audits are coming

### DIFF
--- a/docs/vault/_category_.json
+++ b/docs/vault/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "Vaults",
-  "position": 9,
-  "link": null
-}

--- a/docs/vault/vaults-on-panoptic.md
+++ b/docs/vault/vaults-on-panoptic.md
@@ -1,8 +1,0 @@
----
-sidebar_position: 1
-label: "Vaults on Panoptic"
-title: "Vaults on Panoptic"
-description: "Using Vaults to invite backers and share in the profits"
----
-
-Vaults are dope yo


### PR DESCRIPTION
- The Smart Contract Audits section of this page should likely be renamed the Core Protocol Audits, since the Vaults are also smart contracts
- I also think it makes sense to keep the Core Protocol Audits first - vaults depends on the security of the core protocol anyways, and i do think generally more people will be looking for those audits
- I also indicated that we have more vault audits coming - the current wording (“The Panoptic vault infrastructure audit”) makes it sound like c4 is the only one we plan to do

Resulting in:

<img width="363" height="673" alt="Screenshot 2025-08-13 at 12 58 23 PM" src="https://github.com/user-attachments/assets/3dee517e-b7fc-47dc-9221-4076bdf9de05" />
