### PR TITLE
fix: new announcements need a new ID, otherwise dismissing a past announcement causes new ones to not show up

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -165,7 +165,7 @@ const config = {
         },
       ],
       announcementBar: {
-        id: "ETH_Denver_2023",
+        id: "Vulnerability_claims_open",
         content: `
           A vulnerability was discovered in the Panoptic smart contracts. 
           All user funds have been


### PR DESCRIPTION
fixing the vuln announcement specifically here