### PR TITLE
Fix dark-mode blog/research post navigation background

### DIFF
--- a/src/theme/BlogPostPage/BlogPostRelatedPosts/BlogPostRelatedPosts.css
+++ b/src/theme/BlogPostPage/BlogPostRelatedPosts/BlogPostRelatedPosts.css
@@ -1,11 +1,11 @@
 
 .blog-page-related-posts {
-  background-color: var(--color-surface);
+  background-color: transparent;
   padding: 20px 80px 48px 80px;
 }
 
 .related-posts-title {
-  color: black;
+  color: #E8E0F5;
 }
 
 .page-one {
@@ -15,7 +15,7 @@
 
 @media screen and (max-width: 767px) { 
   .blog-page-related-posts {
-    background-color: var(--color-surface);
+    background-color: transparent;
     padding: 20px 16px 32px 16px;
   }
 }

--- a/src/theme/BlogPostPage/BlogPostRelatedPosts/RelatedPostItem.css
+++ b/src/theme/BlogPostPage/BlogPostRelatedPosts/RelatedPostItem.css
@@ -1,19 +1,22 @@
 
 .related-post-item {
-  border: 1px solid var(--color-border);
-  background-color: #FFF;
+  border: 1px solid rgba(123, 63, 228, 0.15);
+  background: rgba(19, 8, 40, 0.5);
   border-radius: 16px;
   padding: 16px;
   height: 200px;
   width: 250px;
+  transition: all 0.2s ease;
 }
 
 .related-post-item:hover {
-  color: var(--color-primary);
+  border-color: rgba(123, 63, 228, 0.35);
+  box-shadow: 0 0 20px rgba(123, 63, 228, 0.1);
   cursor: pointer;
 }
 
 .related-post-item-sublabel {
   padding: 0 26px;
+  color: rgba(232, 224, 245, 0.7);
 }
 


### PR DESCRIPTION
Same light-background issue as doc pagination, in the duplicate BlogPostRelatedPosts components used by blog and research pages.